### PR TITLE
На мобильном устройстве ширина страницы больше размера экрана и появляется горизонтальный скролл

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -5,6 +5,9 @@ body, button, select, input{
   font-family: "Helios-Cond-Regular", "Helvetica Neue";
   }
 body{
+  position: relative;
+  overflow: hidden;
+  -webkit-tap-highlight-color: transparent;
   background: $color-white;
   line-height: 1;
   min-width: 812px;


### PR DESCRIPTION
На мобильном устройстве ширина страницы больше размера экрана и появляется горизонтальный скролл
![IMG_9660](https://user-images.githubusercontent.com/10209901/216031140-104cb745-ddc7-4507-9c08-2bd4c51fd353.jpg)
также убрал подсветку у тапов на айфоне
![IMG_9663](https://user-images.githubusercontent.com/10209901/216032531-8b1cb53b-6fff-4a05-81c6-a106982d9c13.jpg)
